### PR TITLE
fix: When we cant find some postContentMedia dont fail

### DIFF
--- a/modularity-graphql.php
+++ b/modularity-graphql.php
@@ -370,11 +370,12 @@ add_action(
             $post_content,
             $matches
           );
-          $posts = array_map(function ($id) {
-            $post = get_post($id);
-            return new Post($post);
-          }, array_unique($matches[1]));
-          return $posts;
+          return array_filter(
+            array_map(function ($id) {
+              $post = get_post($id);
+              return !empty($post) ? new Post($post) : null;
+            }, array_unique($matches[1]))
+          );
         },
       ]
     );


### PR DESCRIPTION
This is related to https://github.com/whitespace-se/wordpress-plugin-wp-graphql-extras/pull/1 since it relies on the exact same lines of code. 

And the same fix is with this pull request applied also to this module. 

